### PR TITLE
[Website_sale] FIX: Show product filter menu on mobile

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -268,7 +268,7 @@
       </ul>
   </xpath>
   <xpath expr="//div[@id='products_grid_before']" position="attributes">
-      <attribute name="class">col-md-3 hidden-xs</attribute>
+      <attribute name="class">col-md-3</attribute>
   </xpath>
   <xpath expr="//div[@id='products_grid']" position="attributes">
       <attribute name="class">col-md-9</attribute>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When opening the webshop on mobile you will not be able to filter out products.
View on computer:
![image](https://cloud.githubusercontent.com/assets/6352350/19677321/0e1dcd90-9a99-11e6-902e-35027520cd51.png)
View on mobile:
![image](https://cloud.githubusercontent.com/assets/6352350/19677338/2671411a-9a99-11e6-9ba9-f1ac3d88751d.png)


Current behavior before PR: You're unable to filter out products on mobile.

Desired behavior after PR is merged: You're able to filter out products on mobile.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Before this fix the menu for filtering out products (such as product categories) was not shown on mobile due to the hidden-xs class appended.
This should be shown, otherwise users on the webshop cannot filter products in the shop.