### PR TITLE
[stock] IMP: remove unused logger import

### DIFF
--- a/addons/stock/controllers/main.py
+++ b/addons/stock/controllers/main.py
@@ -1,10 +1,6 @@
 # -*- coding: utf-8 -*-
-import logging
-
 from odoo import http
 from odoo.http import request
-
-_logger = logging.getLogger(__name__)
 
 
 class BarcodeController(http.Controller):


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Remove unused logger import.

Current behavior before PR: The logger is imported but never used.

Desired behavior after PR is merged: The logger is no longer imported as it is not used.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr