### PR TITLE
[Fleet] IMP: Make fleet vehicle tags translatable

### DIFF
--- a/addons/fleet/models/fleet.py
+++ b/addons/fleet/models/fleet.py
@@ -64,7 +64,7 @@ class FleetVehicleCost(models.Model):
 class FleetVehicleTag(models.Model):
     _name = 'fleet.vehicle.tag'
 
-    name = fields.Char(required=True)
+    name = fields.Char(required=True, translate=True)
     color = fields.Integer('Color Index')
 
     _sql_constraints = [('name_uniq', 'unique (name)', "Tag name already exists !")]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR: It is impossible to translate fleet vehicle tags:
![image](https://cloud.githubusercontent.com/assets/6352350/20526292/b9a49d7a-b0c3-11e6-8b09-464074330721.png)


Desired behavior after PR is merged: You can translate fleet vehicle tags.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

