### PR TITLE
[Fix] Add xls import in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -34,6 +34,7 @@ recursive-include openerp *.woff2
 recursive-include openerp *.wsdl
 recursive-include openerp *.xsd
 recursive-include openerp *.xsl
+recursive-include openerp *.xls
 recursive-include openerp *.xml
 recursive-include openerp *.yml
 recursive-exclude * *.py[co]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

The import was missing for xls files.