### PR TITLE
[Base] ADD: Check on already used field(s) in inherited views

### DIFF
--- a/odoo/addons/base/ir/ir_ui_view.py
+++ b/odoo/addons/base/ir/ir_ui_view.py
@@ -769,7 +769,13 @@ actual arch.
 
         for f in node:
             if children or (node.tag == 'field' and f.tag in ('filter', 'separator')):
-                fields.update(self.postprocess(model, f, view_id, in_tree_view, model_fields))
+                postprocess_fields = self.postprocess(model, f, view_id, in_tree_view, model_fields)
+                union = list(set(fields) & set(postprocess_fields))
+                if union:
+                    # This will give the name of the view (record) in the database. It is better than just an ID. 
+                    view_name = self.env['ir.ui.view'].search([('id', '=', view_id)]).name
+                    _logger.warning("The fields %s are already present in the view definition (view name: %s, view id: %s model: %s, tag in the view: %s).", union, view_name, view_id, model, f.tag)
+                fields.update(postprocess_fields)
 
         orm.transfer_modifiers_to_node(modifiers, node)
         return fields


### PR DESCRIPTION
By default Odoo does not detect if a field is already defined in another view or not. This can however lead to strange issues when you want to add this same field to another view again and when you add an @api.onchange on this field. (For more information see https://github.com/odoo/odoo/issues/15111). 
An example usecase:
Imagine having a view named `product.template.product.form`. On this view you show the field `barcode` in some tab. After a few months you create a new view named `product.template.product.form.inherit` that inherits the already existing view `product.template.product.form`. For some reason you however forget that the original view already shows the `barcode` field and you add it in the new view.
In this case you will have the same field (`barcode`) twice in the view. Once from the view `product.template.product.form` and once from the view `product.template.product.form`. When you would now do an @api.onchange you would get very strange behaviour, not to mention that you basically didn't even need this field on the view, since it was already there.
This PR shows a warning in the logfile when this issue happens.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
