### PR TITLE
[FIX] Load correct chart data for chinese accounting

### DIFF
--- a/addons/l10n_cn_standard/__manifest__.py
+++ b/addons/l10n_cn_standard/__manifest__.py
@@ -30,7 +30,7 @@ Including the following data in the Accounting Standards for Business Enterprise
     """,
     'depends': ['l10n_cn'],
     'data': [
-        'data/l10n_chart_china_standard_business_chart_data.xml',
+        'data/l10n_cn_standard_chart_data.xml',
         'data/account.account.template.csv',
         'data/account_tax_templates.xml',
         'data/account_chart_template_data.xml',


### PR DESCRIPTION
The manifest loaded l10n_chart_china_standard_business_chart_data.xml but this file no longer exists in Odoo. This is probably a migration issue. Changed to the new XML file.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
