### PR TITLE
[IMP] website_forum: make blog titles and forum tags translatable

### DIFF
--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -194,7 +194,7 @@ class Post(models.Model):
     _inherit = ['mail.thread', 'website.seo.metadata']
     _order = "is_correct DESC, vote_count DESC, write_date DESC"
 
-    name = fields.Char('Title')
+    name = fields.Char('Title', translate=True)
     forum_id = fields.Many2one('forum.forum', string='Forum', required=True)
     content = fields.Html('Content', strip_style=True)
     plain_content = fields.Text('Plain Content', compute='_get_plain_content', store=True)
@@ -911,7 +911,7 @@ class Tags(models.Model):
     _description = "Forum Tag"
     _inherit = ['mail.thread', 'website.seo.metadata']
 
-    name = fields.Char('Name', required=True)
+    name = fields.Char('Name', required=True, translate=True)
     create_uid = fields.Many2one('res.users', string='Created by', readonly=True)
     forum_id = fields.Many2one('forum.forum', string='Forum', required=True)
     post_ids = fields.Many2many(


### PR DESCRIPTION
Description of the issue/feature this PR addresses: You can't translate blog titles or forum tags.

Current behavior before PR:  You can't translate blog titles or forum tags.

Desired behavior after PR is merged: You can translate the blog titles and the forum tags (just like you can translate blog tags for example).

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
